### PR TITLE
cleanup after download

### DIFF
--- a/svg-crowbar.js
+++ b/svg-crowbar.js
@@ -184,6 +184,7 @@
 
     setTimeout(function() {
       window.URL.revokeObjectURL(url);
+      cleanup();
     }, 10);
   }
 


### PR DESCRIPTION
After downloading, remove all crowbar elements to make the page functional again. Fixes #4
