### PR TITLE
Explicitly setting styles on all nodes instead of embedding css declaration

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
 
   <h3>The Bookmarklet</h3>
   <p>
-    <a class="bookmarklet" href="javascript:javascript: (function () { var e = document.createElement('script'); if (window.location.protocol === 'https:') { e.setAttribute('src', 'https://raw.github.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar.js'); } else { e.setAttribute('src', 'http://nytimes.github.com/svg-crowbar/svg-crowbar.js'); } e.setAttribute('class', 'svg-crowbar'); document.body.appendChild(e); })();">SVG Crowbar</a>&nbsp;
+    <a class="bookmarklet" href="javascript:javascript: (function () { var e = document.createElement('script'); if (window.location.protocol === 'https:') { e.setAttribute('src', 'https://raw.github.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar.js'); } else { e.setAttribute('src', 'http://nytimes.github.com/svg-crowbar/gh-pages/svg-crowbar.js'); } e.setAttribute('class', 'svg-crowbar'); document.body.appendChild(e); })();">SVG Crowbar</a>&nbsp;
     <span>← Drag this to your bookmarks bar.</span>
   </p>
   <p>After you’ve installed the bookmarklet, you can execute it on any page. Go ahead and try it out on this <a href="http://bl.ocks.org/mbostock/4458497">crazy map</a>.</p>

--- a/index.html
+++ b/index.html
@@ -76,11 +76,20 @@
 
   <h3>The Bookmarklet</h3>
   <p>
-    <a class="bookmarklet" href="javascript:javascript: (function () { var e = document.createElement('script'); if (window.location.protocol === 'https:') { e.setAttribute('src', 'https://raw.github.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar.js'); } else { e.setAttribute('src', 'http://nytimes.github.com/svg-crowbar/gh-pages/svg-crowbar.js'); } e.setAttribute('class', 'svg-crowbar'); document.body.appendChild(e); })();">SVG Crowbar</a>&nbsp;
+    <a class="bookmarklet" href="javascript:javascript: (function () { var e = document.createElement('script'); if (window.location.protocol === 'https:') { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar.js'); } else { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar.js'); } e.setAttribute('class', 'svg-crowbar'); document.body.appendChild(e); })();">SVG Crowbar</a>&nbsp;
     <span>← Drag this to your bookmarks bar.</span>
   </p>
+
   <p>After you’ve installed the bookmarklet, you can execute it on any page. Go ahead and try it out on this <a href="http://bl.ocks.org/mbostock/4458497">crazy map</a>.</p>
   <p class="note">(You can click on the link instead to test it on this page immediately.)</p>
+
+  <h3>Update</h3>
+  <p>
+    Some users reported that styles were not stored with the SVG files, so we added a new version that should work on everywhere. The new method is slower, so loading can take a while on pages with a many SVG elements. Still in beta, but feel free to try.
+  </p>
+  <p>
+    <a class="bookmarklet" href="javascript:javascript: (function () { var e = document.createElement('script'); if (window.location.protocol === 'https:') { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar-2.js'); } else { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar-2.js'); } e.setAttribute('class', 'svg-crowbar'); document.body.appendChild(e); })();">SVG Crowbar 2</a>&nbsp; <span>← Drag this to your bookmarks bar.</span>
+  <p>
 
   <h3>Notes</h3>
   <p>Pixels will map to points when opening in Illustrator.</p>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,10 @@
       color: white;
     }
 
+    .bookmarklet.ver2 {
+      background: #3FAA90;
+    }
+
     #svgs {
       margin: 20px 0;
     }
@@ -88,7 +92,7 @@
     Some users reported that styles were not stored with the SVG files, so we added a new version that should work on everywhere. The new method is slower, so loading can take a while on pages with a many SVG elements. Still in beta, but feel free to try.
   </p>
   <p>
-    <a class="bookmarklet" href="javascript:javascript: (function () { var e = document.createElement('script'); if (window.location.protocol === 'https:') { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar-2.js'); } else { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar-2.js'); } e.setAttribute('class', 'svg-crowbar'); document.body.appendChild(e); })();">SVG Crowbar 2</a>&nbsp; <span>← Drag this to your bookmarks bar.</span>
+    <a class="bookmarklet ver2" href="javascript:javascript: (function () { var e = document.createElement('script'); if (window.location.protocol === 'https:') { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar-2.js'); } else { e.setAttribute('src', 'https://rawgit.com/NYTimes/svg-crowbar/gh-pages/svg-crowbar-2.js'); } e.setAttribute('class', 'svg-crowbar'); document.body.appendChild(e); })();">SVG Crowbar 2</a>&nbsp; <span>← Drag this to your bookmarks bar.</span>
   <p>
 
   <h3>Notes</h3>

--- a/svg-crowbar-2.js
+++ b/svg-crowbar-2.js
@@ -1,0 +1,248 @@
+(function() {
+  var doctype = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">';
+
+  window.URL = (window.URL || window.webkitURL);
+
+  var body = document.body,
+      emptySvg;
+
+  var prefix = {
+    xmlns: "http://www.w3.org/2000/xmlns/",
+    xlink: "http://www.w3.org/1999/xlink",
+    svg: "http://www.w3.org/2000/svg"
+  };
+
+  initialize();
+
+  function initialize() {
+    var documents = [window.document],
+        SVGSources = [];
+        iframes = document.querySelectorAll("iframe");
+
+    // add empty svg element
+    var emptySvg = window.document.createElementNS(prefix.svg, 'svg');
+    window.document.body.appendChild(emptySvg);
+    var emptySvgDeclarationComputed = getComputedStyle(emptySvg);
+
+    [].forEach.call(iframes, function(el) {
+      try {
+        if (el.contentDocument) {
+          documents.push(el.contentDocument);
+        }
+      } catch(err) {
+        console.log(err);
+      }
+    });
+
+    documents.forEach(function(doc) {
+      var newSources = getSources(doc, emptySvgDeclarationComputed);
+      // because of prototype on NYT pages
+      for (var i = 0; i < newSources.length; i++) {
+        SVGSources.push(newSources[i]);
+      }
+    });
+    if (SVGSources.length > 1) {
+      createPopover(SVGSources);
+    } else if (SVGSources.length > 0) {
+      download(SVGSources[0]);
+    } else {
+      alert("The Crowbar couldn’t find any SVG nodes.");
+    }
+
+  }
+
+  function createPopover(sources) {
+    cleanup();
+
+    sources.forEach(function(s1) {
+      sources.forEach(function(s2) {
+        if (s1 !== s2) {
+          if ((Math.abs(s1.top - s2.top) < 38) && (Math.abs(s1.left - s2.left) < 38)) {
+            s2.top += 38;
+            s2.left += 38;
+          }
+        }
+      });
+    });
+
+    var buttonsContainer = document.createElement("div");
+    body.appendChild(buttonsContainer);
+
+    buttonsContainer.setAttribute("class", "svg-crowbar");
+    buttonsContainer.style["z-index"] = 1e7;
+    buttonsContainer.style["position"] = "absolute";
+    buttonsContainer.style["top"] = 0;
+    buttonsContainer.style["left"] = 0;
+
+
+
+    var background = document.createElement("div");
+    body.appendChild(background);
+
+    background.setAttribute("class", "svg-crowbar");
+    background.style["background"] = "rgba(255, 255, 255, 0.7)";
+    background.style["position"] = "fixed";
+    background.style["left"] = 0;
+    background.style["top"] = 0;
+    background.style["width"] = "100%";
+    background.style["height"] = "100%";
+
+    sources.forEach(function(d, i) {
+      var buttonWrapper = document.createElement("div");
+      buttonsContainer.appendChild(buttonWrapper);
+      buttonWrapper.setAttribute("class", "svg-crowbar");
+      buttonWrapper.style["position"] = "absolute";
+      buttonWrapper.style["top"] = (d.top + document.body.scrollTop) + "px";
+      buttonWrapper.style["left"] = (document.body.scrollLeft + d.left) + "px";
+      buttonWrapper.style["padding"] = "4px";
+      buttonWrapper.style["border-radius"] = "3px";
+      buttonWrapper.style["color"] = "white";
+      buttonWrapper.style["text-align"] = "center";
+      buttonWrapper.style["font-family"] = "'Helvetica Neue'";
+      buttonWrapper.style["background"] = "rgba(0, 0, 0, 0.8)";
+      buttonWrapper.style["box-shadow"] = "0px 4px 18px rgba(0, 0, 0, 0.4)";
+      buttonWrapper.style["cursor"] = "move";
+      buttonWrapper.textContent =  "SVG #" + i + ": " + (d.id ? "#" + d.id : "") + (d.class ? "." + d.class : "");
+
+      var button = document.createElement("button");
+      buttonWrapper.appendChild(button);
+      button.setAttribute("data-source-id", i);
+      button.style["width"] = "150px";
+      button.style["font-size"] = "12px";
+      button.style["line-height"] = "1.4em";
+      button.style["margin"] = "5px 0 0 0";
+      button.textContent = "Download";
+
+      button.onclick = function(el) {
+        // console.log(el, d, i, sources)
+        download(d);
+      };
+
+    });
+
+  }
+
+  function cleanup() {
+    var crowbarElements = document.querySelectorAll(".svg-crowbar");
+
+    [].forEach.call(crowbarElements, function(el) {
+      el.parentNode.removeChild(el);
+    });
+  }
+
+
+  function getSources(doc, emptySvgDeclarationComputed) {
+    var svgInfo = [],
+        svgs = doc.querySelectorAll("svg");
+
+    [].forEach.call(svgs, function (svg) {
+
+      svg.setAttribute("version", "1.1");
+
+      // removing attributes so they aren't doubled up
+      svg.removeAttribute("xmlns");
+      svg.removeAttribute("xlink");
+
+      // These are needed for the svg
+      if (!svg.hasAttributeNS(prefix.xmlns, "xmlns")) {
+        svg.setAttributeNS(prefix.xmlns, "xmlns", prefix.svg);
+      }
+
+      if (!svg.hasAttributeNS(prefix.xmlns, "xmlns:xlink")) {
+        svg.setAttributeNS(prefix.xmlns, "xmlns:xlink", prefix.xlink);
+      }
+
+      setInlineStyles(svg, emptySvgDeclarationComputed);
+
+      var source = (new XMLSerializer()).serializeToString(svg);
+      var rect = svg.getBoundingClientRect();
+      svgInfo.push({
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height,
+        class: svg.getAttribute("class"),
+        id: svg.getAttribute("id"),
+        childElementCount: svg.childElementCount,
+        source: [doctype + source]
+      });
+    });
+    return svgInfo;
+  }
+
+  function download(source) {
+    var filename = "untitled";
+
+    if (source.id) {
+      filename = source.id;
+    } else if (source.class) {
+      filename = source.class;
+    } else if (window.document.title) {
+      filename = window.document.title.replace(/[^a-z0-9]/gi, '-').toLowerCase();
+    }
+
+    var url = window.URL.createObjectURL(new Blob(source.source, { "type" : "text\/xml" }));
+
+    var a = document.createElement("a");
+    body.appendChild(a);
+    a.setAttribute("class", "svg-crowbar");
+    a.setAttribute("download", filename + ".svg");
+    a.setAttribute("href", url);
+    a.style["display"] = "none";
+    a.click();
+
+    setTimeout(function() {
+      window.URL.revokeObjectURL(url);
+    }, 10);
+  }
+
+
+  function setInlineStyles(svg, emptySvgDeclarationComputed) {
+    
+    function explicitlySetStyle (element) {
+      var cSSStyleDeclarationComputed = getComputedStyle(element);
+      var i, len, key, value;
+      var computedStyleStr = "";
+      for (i=0, len=cSSStyleDeclarationComputed.length; i<len; i++) {
+        key=cSSStyleDeclarationComputed[i];
+        value=cSSStyleDeclarationComputed.getPropertyValue(key);
+        if (value!==emptySvgDeclarationComputed.getPropertyValue(key) && key != 'font-family') {
+          computedStyleStr+=key+":"+value+";";
+        }
+      }
+      if (element.tagName == 'text' || element.tagName == 'tspan') {
+        computedStyleStr += 'font-size:'+cSSStyleDeclarationComputed.fontSize+';';
+        var fw = cSSStyleDeclarationComputed.fontWeight,
+            ff = 'NYTFranklin' + (fw == 300 || fw == 'light' ? 'Light' : fw > 400 || fw == 'bold' ? 'Bold' : 'Medium');
+        computedStyleStr += 'font-family:'+ff+';';
+      }
+      element.setAttribute('style', computedStyleStr);
+    }
+    function traverse(obj){
+      var tree = [];
+      tree.push(obj);
+      visit(obj);
+      function visit(node) {
+        if (node && node.hasChildNodes()) {
+          var child = node.firstChild;
+          while (child) {
+            if (child.nodeType === 1 && child.nodeName != 'SCRIPT'){
+              tree.push(child);
+              visit(child);
+            }
+            child = child.nextSibling;
+          }
+        }
+      }
+      return tree;
+    }
+    // hardcode computed css styles inside svg
+    var allElements = traverse(svg);
+    var i = allElements.length;
+    while (i--){
+      explicitlySetStyle(allElements[i]);
+    }
+  }
+
+
+})();

--- a/svg-crowbar.js
+++ b/svg-crowbar.js
@@ -9,7 +9,7 @@
     xmlns: "http://www.w3.org/2000/xmlns/",
     xlink: "http://www.w3.org/1999/xlink",
     svg: "http://www.w3.org/2000/svg"
-  }
+  };
 
   initialize();
 
@@ -24,7 +24,7 @@
           documents.push(el.contentDocument);
         }
       } catch(err) {
-        console.log(err)
+        console.log(err);
       }
     });
 
@@ -34,8 +34,8 @@
       // because of prototype on NYT pages
       for (var i = 0; i < newSources.length; i++) {
         SVGSources.push(newSources[i]);
-      };
-    })
+      }
+    });
     if (SVGSources.length > 1) {
       createPopover(SVGSources);
     } else if (SVGSources.length > 0) {
@@ -56,7 +56,7 @@
             s2.left += 38;
           }
         }
-      })
+      });
     });
 
     var buttonsContainer = document.createElement("div");
@@ -100,7 +100,7 @@
 
       var button = document.createElement("button");
       buttonWrapper.appendChild(button);
-      button.setAttribute("data-source-id", i)
+      button.setAttribute("data-source-id", i);
       button.style["width"] = "150px";
       button.style["font-size"] = "12px";
       button.style["line-height"] = "1.4em";
@@ -139,7 +139,7 @@
       svg.insertBefore(defsEl, svg.firstChild); //TODO   .insert("defs", ":first-child")
       // defsEl.setAttribute("class", "svg-crowbar");
 
-      var styleEl = document.createElement("style")
+      var styleEl = document.createElement("style");
       defsEl.appendChild(styleEl);
       styleEl.setAttribute("type", "text/css");
 

--- a/svg-crowbar.js
+++ b/svg-crowbar.js
@@ -3,7 +3,8 @@
 
   window.URL = (window.URL || window.webkitURL);
 
-  var body = document.body;
+  var body = document.body,
+      emptySvg;
 
   var prefix = {
     xmlns: "http://www.w3.org/2000/xmlns/",
@@ -18,6 +19,11 @@
         SVGSources = [];
         iframes = document.querySelectorAll("iframe");
 
+    // add empty svg element
+    var emptySvg = window.document.createElementNS(prefix.svg, 'svg');
+    window.document.body.appendChild(emptySvg);
+    var emptySvgDeclarationComputed = getComputedStyle(emptySvg);
+
     [].forEach.call(iframes, function(el) {
       try {
         if (el.contentDocument) {
@@ -29,8 +35,7 @@
     });
 
     documents.forEach(function(doc) {
-      var styles = getStyles(doc);
-      var newSources = getSources(doc, styles);
+      var newSources = getSources(doc, emptySvgDeclarationComputed);
       // because of prototype on NYT pages
       for (var i = 0; i < newSources.length; i++) {
         SVGSources.push(newSources[i]);
@@ -43,6 +48,7 @@
     } else {
       alert("The Crowbar couldn’t find any SVG nodes.");
     }
+
   }
 
   function createPopover(sources) {
@@ -125,24 +131,13 @@
   }
 
 
-  function getSources(doc, styles) {
+  function getSources(doc, emptySvgDeclarationComputed) {
     var svgInfo = [],
         svgs = doc.querySelectorAll("svg");
-
-    styles = (styles === undefined) ? "" : styles;
 
     [].forEach.call(svgs, function (svg) {
 
       svg.setAttribute("version", "1.1");
-
-      var defsEl = document.createElement("defs");
-      svg.insertBefore(defsEl, svg.firstChild); //TODO   .insert("defs", ":first-child")
-      // defsEl.setAttribute("class", "svg-crowbar");
-
-      var styleEl = document.createElement("style");
-      defsEl.appendChild(styleEl);
-      styleEl.setAttribute("type", "text/css");
-
 
       // removing attributes so they aren't doubled up
       svg.removeAttribute("xmlns");
@@ -157,7 +152,9 @@
         svg.setAttributeNS(prefix.xmlns, "xmlns:xlink", prefix.xlink);
       }
 
-      var source = (new XMLSerializer()).serializeToString(svg).replace('</style>', '<![CDATA[' + styles + ']]></style>');
+      setInlineStyles(svg, emptySvgDeclarationComputed);
+
+      var source = (new XMLSerializer()).serializeToString(svg);
       var rect = svg.getBoundingClientRect();
       svgInfo.push({
         top: rect.top,
@@ -199,35 +196,53 @@
     }, 10);
   }
 
-  function getStyles(doc) {
-    var styles = "",
-        styleSheets = doc.styleSheets;
 
-    if (styleSheets) {
-      for (var i = 0; i < styleSheets.length; i++) {
-        processStyleSheet(styleSheets[i]);
+  function setInlineStyles(svg, emptySvgDeclarationComputed) {
+    
+    function explicitlySetStyle (element) {
+      var cSSStyleDeclarationComputed = getComputedStyle(element);
+      var i, len, key, value;
+      var computedStyleStr = "";
+      for (i=0, len=cSSStyleDeclarationComputed.length; i<len; i++) {
+        key=cSSStyleDeclarationComputed[i];
+        value=cSSStyleDeclarationComputed.getPropertyValue(key);
+        if (value!==emptySvgDeclarationComputed.getPropertyValue(key) && key != 'font-family') {
+          computedStyleStr+=key+":"+value+";";
+        }
       }
+      if (element.tagName == 'text' || element.tagName == 'tspan') {
+        computedStyleStr += 'font-size:'+cSSStyleDeclarationComputed.fontSize+';';
+        var fw = cSSStyleDeclarationComputed.fontWeight,
+            ff = 'NYTFranklin' + (fw == 300 || fw == 'light' ? 'Light' : fw > 400 || fw == 'bold' ? 'Bold' : 'Medium');
+        computedStyleStr += 'font-family:'+ff+';';
+      }
+      element.setAttribute('style', computedStyleStr);
     }
-
-    function processStyleSheet(ss) {
-      if (ss.cssRules) {
-        for (var i = 0; i < ss.cssRules.length; i++) {
-          var rule = ss.cssRules[i];
-          if (rule.type === 3) {
-            // Import Rule
-            processStyleSheet(rule.styleSheet);
-          } else {
-            // hack for illustrator crashing on descendent selectors
-            if (rule.selectorText) {
-              if (rule.selectorText.indexOf(">") === -1) {
-                styles += "\n" + rule.cssText;
-              }
+    function traverse(obj){
+      var tree = [];
+      tree.push(obj);
+      visit(obj);
+      function visit(node) {
+        if (node && node.hasChildNodes()) {
+          var child = node.firstChild;
+          while (child) {
+            if (child.nodeType === 1 && child.nodeName != 'SCRIPT'){
+              tree.push(child);
+              visit(child);
             }
+            child = child.nextSibling;
           }
         }
       }
+      return tree;
     }
-    return styles;
+    // hardcode computed css styles inside svg
+    var allElements = traverse(svg);
+    var i = allElements.length;
+    while (i--){
+      explicitlySetStyle(allElements[i]);
+    }
   }
+
 
 })();


### PR DESCRIPTION
In the current version of svg-crowbar the embedding of styles is not working in all situations.

I replaced the old technique with a solution that traverses the SVG DOM and for each element applies all style properties that are different from the default styles of an empty SVG element. The styles are computed using `getComputedStyles()`.

The original implementation was taken from Stackoverflow though I don't remember where I found it. It works pretty well, but it is comparably slower than the old method.

It might make sense to wait with the getSources() call until the user actually clicked the download.
